### PR TITLE
Add SignalForwardingDelay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Usage:
   ecswrap [OPTIONS] -- COMMAND [ARGS]
 
 Application Options:
-      --stop-wait-timeout= Maximum time duration in seconds to wait from when the process receives SIGTERM before sending SIGTERM to the child. This value should be less than ECS_CONTAINER_STOP_TIMEOUT.
-                           (default: 10) [$ECSWRAP_STOP_WAIT_TIMEOUT]
-      --linked-container=  Container names linked with the container where this program is running. [$ECSWRAP_LINKED_CONTAINERS]
-  -v, --verbose            Verbosity
+      --stop-wait-timeout=       Maximum time duration in seconds to wait from when the process receives SIGTERM before sending SIGTERM to the child. This value should be less than
+                                 ECS_CONTAINER_STOP_TIMEOUT. (default: 10) [$ECSWRAP_STOP_WAIT_TIMEOUT]
+      --linked-container=        container names linked with the container where this program is running. [$ECSWRAP_LINKED_CONTAINERS]
+      --signal-forwarding-delay= Delay seconds until forwarding a signal, which is SIGTERM, SIGQUIT or SIGINT,to child processes. (default: 0) [$ECSWRAP_SIGNAL_FORWARDING_DELAY]
+  -v, --verbose                  Verbosity
 
 Help Options:
-  -h, --help               Show this help message
-
+  -h, --help                     Show this help message
 ```
 
 ## Example

--- a/main_test.go
+++ b/main_test.go
@@ -143,6 +143,8 @@ func TestStart(t *testing.T) {
 
 		exitStatus := make(chan int)
 		go func() {
+			defer close(exitStatus)
+
 			process, _ := os.FindProcess(os.Getpid())
 			process.Signal(syscall.SIGTERM)
 			linkedContainer.KnownStatus = "STOPPED"
@@ -157,7 +159,6 @@ func TestStart(t *testing.T) {
 			case <-time.After(time.Duration(timeout+signalForwardingDelay+1) * time.Second):
 				t.Errorf("timeout")
 			}
-			close(exitStatus)
 		}()
 
 		status, err := cp.wait()

--- a/main_test.go
+++ b/main_test.go
@@ -151,13 +151,14 @@ func TestStart(t *testing.T) {
 
 			want := 128 + int(syscall.SIGTERM)
 			select {
-			case got := <-exitStatus:
-				if got != want {
-					t.Errorf("exitStatus: got: %v, want: %v", got, want)
-				}
-				return
-			case <-time.After(time.Duration(timeout+signalForwardingDelay+1) * time.Second):
-				t.Errorf("timeout")
+			case <-exitStatus:
+				t.Errorf("not wait for signalForwardingDelay")
+			case <-time.After(time.Duration(float64(signalForwardingDelay)+0.5) * time.Second):
+			}
+
+			got := <-exitStatus
+			if got != want {
+				t.Errorf("exitStatus: got: %v, want: %v", got, want)
 			}
 		}()
 


### PR DESCRIPTION
We'd like to wait a few seconds for forwarding a signal to child processes in case that a container should not be received a signal until deleting information about the container from other
service discovery service (like envoy's CDS https://www.envoyproxy.io/docs/envoy/latest/configuration/cluster_manager/cds#config-cluster-manager-cds)